### PR TITLE
18 fix/authorization 유저 권한에 따른 서비스 이용 범위 세팅

### DIFF
--- a/backend/src/main/java/com/whereismyhome/board/controller/BoardController.java
+++ b/backend/src/main/java/com/whereismyhome/board/controller/BoardController.java
@@ -50,4 +50,11 @@ public class BoardController {
         List<BoardListResponseDto> boardList = boardService.setId(boardListResponseDtos, id);
         return new ResponseEntity(boardList, HttpStatus.OK);
     }
+
+    //테스트
+    @GetMapping("/answer")
+    public ResponseEntity test(){
+
+        return ResponseEntity.ok().body("답변 작성 메서드 요청 성공");
+    }
 }

--- a/backend/src/main/java/com/whereismyhome/config/SecurityConfig.java
+++ b/backend/src/main/java/com/whereismyhome/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -32,7 +31,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeHttpRequests()
-                .requestMatchers("/notice/write", "/board/answer").hasRole("ADMIN")
+                .requestMatchers("/notice/write","board/answer").hasRole("ADMIN")
                 .requestMatchers("/h2/**").permitAll()
                 .anyRequest().permitAll()
                 .and()

--- a/backend/src/main/java/com/whereismyhome/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/whereismyhome/jwt/JwtAuthenticationFilter.java
@@ -2,7 +2,6 @@ package com.whereismyhome.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,11 +21,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.debug("filter 메소드 실행");
-
+        log.info("filter 메소드 실행");
+        
         String token = jwtProvider.getTokenFromCookie(request);
+        System.out.println("token = " + token);
         //쿠키가 있으면
         if(token != null){
+            log.info("쿠키있음");
             setAuthentication(token);
         }
         filterChain.doFilter(request,response);

--- a/backend/src/main/java/com/whereismyhome/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/whereismyhome/jwt/JwtProvider.java
@@ -3,7 +3,6 @@ package com.whereismyhome.jwt;
 
 import com.whereismyhome.member.repository.MemberRepository;
 import com.whereismyhome.member.service.CustomUserDetailService;
-import com.whereismyhome.role.entity.MemberRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
@@ -22,7 +21,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -42,13 +40,14 @@ public class JwtProvider {
 
 
     //jwt토큰 생성
-    public String createToken(String id, List<MemberRole> roles) {
+    public String createToken(String id, String roles) {
         //토큰 제목
         Claims claims = Jwts.claims().setSubject(id);
 
         //유저 role 넣기 -> (관리자, 유저)
         claims.put("roles", roles);
 
+        log.info("토큰 생성하러 들어감");
         Date date = new Date();
         return Jwts.builder()
                 .setClaims(claims)
@@ -58,7 +57,7 @@ public class JwtProvider {
     }
 
     //엑세스토큰 생성
-    public String createAccessToken(String id, List<MemberRole> roles) {
+    public String createAccessToken(String id, String roles) {
         return this.createToken(id, roles);
     }
 

--- a/backend/src/main/java/com/whereismyhome/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/whereismyhome/jwt/JwtProvider.java
@@ -3,6 +3,7 @@ package com.whereismyhome.jwt;
 
 import com.whereismyhome.member.repository.MemberRepository;
 import com.whereismyhome.member.service.CustomUserDetailService;
+import com.whereismyhome.role.entity.MemberRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
@@ -41,7 +42,7 @@ public class JwtProvider {
 
 
     //jwt토큰 생성
-    public String createToken(String id, List<String> roles) {
+    public String createToken(String id, List<MemberRole> roles) {
         //토큰 제목
         Claims claims = Jwts.claims().setSubject(id);
 
@@ -57,7 +58,7 @@ public class JwtProvider {
     }
 
     //엑세스토큰 생성
-    public String createAccessToken(String id, List<String> roles) {
+    public String createAccessToken(String id, List<MemberRole> roles) {
         return this.createToken(id, roles);
     }
 
@@ -78,10 +79,10 @@ public class JwtProvider {
     public String getTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
-            log.debug("쿠키 있음");
+            log.info("쿠키 있음");
             for (Cookie cookie : cookies) {
                 if (cookie.getName().equals("Authorization")) {
-                    log.debug("찾고 싶은 거 찾음");
+                    log.info("찾고 싶은 거 찾음");
                     return cookie.getValue();
                 }
             }
@@ -96,7 +97,9 @@ public class JwtProvider {
     }
 
     //권한 확인
-    public List<String> getRoles(String id) {
-        return memberRepository.findById(id).get().getRoles();
-    }
+//    public List<String> getRoles(String id) {
+//        return memberRepository.findById(id).get().getRoles();
+//
+//    }
+
 }

--- a/backend/src/main/java/com/whereismyhome/member/controller/MemberController.java
+++ b/backend/src/main/java/com/whereismyhome/member/controller/MemberController.java
@@ -45,7 +45,7 @@ public class MemberController {
             throw new IllegalStateException("아이디 혹은 비밀번호가 잘 못 되었습니다.");
         }
 
-        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRoles());
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRoles().getRole());
         log.info("토큰 정상 생성");
 //        String encode = URLEncoder.encode("Bearer " + accessToken, StandardCharsets.UTF_8);
         String encode = URLEncoder.encode(accessToken, StandardCharsets.UTF_8);

--- a/backend/src/main/java/com/whereismyhome/member/controller/MemberController.java
+++ b/backend/src/main/java/com/whereismyhome/member/controller/MemberController.java
@@ -7,7 +7,6 @@ import com.whereismyhome.member.dto.MemberLoginDto;
 import com.whereismyhome.member.entity.Member;
 import com.whereismyhome.member.service.MemberService;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +46,7 @@ public class MemberController {
         }
 
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRoles());
+        log.info("토큰 정상 생성");
 //        String encode = URLEncoder.encode("Bearer " + accessToken, StandardCharsets.UTF_8);
         String encode = URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
 
@@ -64,6 +64,7 @@ public class MemberController {
     public ResponseEntity logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("Authorization", null);
         cookie.setMaxAge(0);
+        cookie.setPath("/");
 
         response.addCookie(cookie);
 

--- a/backend/src/main/java/com/whereismyhome/member/controller/MemberController.java
+++ b/backend/src/main/java/com/whereismyhome/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/member")
 public class MemberController {
 
@@ -49,6 +51,7 @@ public class MemberController {
         String encode = URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
 
         Cookie cookie = new Cookie("Authorization", encode);
+        cookie.setPath(("/"));
         cookie.setHttpOnly(true);
         cookie.setMaxAge(60 * 60);
         response.addCookie(cookie);
@@ -58,7 +61,7 @@ public class MemberController {
 
     //로그아웃
     @PostMapping("/logout")
-    public ResponseEntity logout(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity logout(HttpServletResponse response) {
         Cookie cookie = new Cookie("Authorization", null);
         cookie.setMaxAge(0);
 

--- a/backend/src/main/java/com/whereismyhome/member/entity/Member.java
+++ b/backend/src/main/java/com/whereismyhome/member/entity/Member.java
@@ -1,8 +1,11 @@
 package com.whereismyhome.member.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.whereismyhome.board.entity.Board;
-import jakarta.persistence.*;
+import com.whereismyhome.role.entity.MemberRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -34,10 +37,9 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "member")
     private List<Board> boardList;
 
-    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-    @ElementCollection(fetch = FetchType.EAGER)
-    @Builder.Default
-    private List<String> roles = new ArrayList<>();
+    @OneToMany(mappedBy = "member")
+    private List<MemberRole> roles = new ArrayList<>();
+
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/backend/src/main/java/com/whereismyhome/member/entity/Member.java
+++ b/backend/src/main/java/com/whereismyhome/member/entity/Member.java
@@ -6,6 +6,7 @@ import com.whereismyhome.role.entity.MemberRole;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
@@ -42,7 +43,9 @@ public class Member implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(this.roles.getRole()));
+        return authorities;
     }
 
     @Override

--- a/backend/src/main/java/com/whereismyhome/member/entity/Member.java
+++ b/backend/src/main/java/com/whereismyhome/member/entity/Member.java
@@ -1,11 +1,9 @@
 package com.whereismyhome.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.whereismyhome.board.entity.Board;
 import com.whereismyhome.role.entity.MemberRole;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -37,8 +35,9 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "member")
     private List<Board> boardList;
 
-    @OneToMany(mappedBy = "member")
-    private List<MemberRole> roles = new ArrayList<>();
+    @JsonBackReference
+    @OneToOne(mappedBy = "member")
+    private MemberRole roles;
 
 
     @Override

--- a/backend/src/main/java/com/whereismyhome/member/service/MemberService.java
+++ b/backend/src/main/java/com/whereismyhome/member/service/MemberService.java
@@ -4,11 +4,12 @@ import com.whereismyhome.member.dto.MemberJoinDto;
 import com.whereismyhome.member.dto.MemberLoginDto;
 import com.whereismyhome.member.entity.Member;
 import com.whereismyhome.member.repository.MemberRepository;
+import com.whereismyhome.role.entity.MemberRole;
+import com.whereismyhome.role.repository.MemberRoleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.Optional;
 
 @Service
@@ -17,6 +18,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MemberRoleRepository memberRoleRepository;
 
     //회원가입
     public void join(MemberJoinDto postDto) throws IllegalAccessException {
@@ -27,10 +29,16 @@ public class MemberService {
                 .password(passwordEncoder.encode(postDto.getPassword()))
                 .email(postDto.getEmail())
                 .name(postDto.getName())
-                .roles(Collections.singletonList("ROLE_USER"))
+//                .roles(roles)
                 .build();
 
+        MemberRole role = new MemberRole();
+        role.setRole("ROLE_USER");
+        role.setMember(member);
+
+//        member.getRoles().add(role);
         memberRepository.save(member);
+        memberRoleRepository.save(role);
     }
 
     //회원 id 중복 검사

--- a/backend/src/main/java/com/whereismyhome/member/service/MemberService.java
+++ b/backend/src/main/java/com/whereismyhome/member/service/MemberService.java
@@ -32,8 +32,13 @@ public class MemberService {
 //                .roles(roles)
                 .build();
 
+        String autho = "ROLE_USER";
+        if(postDto.getId().contains("admin")){
+            autho = "ROLE_ADMIN";
+        }
+
         MemberRole role = new MemberRole();
-        role.setRole("ROLE_USER");
+        role.setRole(autho);
         role.setMember(member);
 
 //        member.getRoles().add(role);

--- a/backend/src/main/java/com/whereismyhome/role/entity/MemberRole.java
+++ b/backend/src/main/java/com/whereismyhome/role/entity/MemberRole.java
@@ -1,0 +1,27 @@
+package com.whereismyhome.role.entity;
+
+import com.whereismyhome.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberRole {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String role;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}
+

--- a/backend/src/main/java/com/whereismyhome/role/repository/MemberRoleRepository.java
+++ b/backend/src/main/java/com/whereismyhome/role/repository/MemberRoleRepository.java
@@ -1,0 +1,7 @@
+package com.whereismyhome.role.repository;
+
+import com.whereismyhome.role.entity.MemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRoleRepository extends JpaRepository<MemberRole,Long> {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/whereismyhome?serverTimezone=UTC&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/whereismyhome2?serverTimezone=UTC&characterEncoding=UTF-8
     username: ssafy
     password: ssafy
 


### PR DESCRIPTION
유저 권한 테이블 따로 생성 후 유저 권한을 긁어와 스프링 시큐리티에 등록 후 요청 수신 시 해당 유저의 권한을 확인하여 서비스 이용 가능, 불가능 여부 판단

![image](https://user-images.githubusercontent.com/66876894/236666003-e248bd0d-ccf2-4199-85c3-7507fb48f375.png)

## ADMIN으로 로그인 하였을 경우
- 현재 발급 받은 토큰에서 유저의 아이디와 권한을 확인 할 수 있음
![image](https://user-images.githubusercontent.com/66876894/236666099-6fba1811-3195-44cc-bb4d-be8d76a231a3.png)

- 게시글의 답변 작성을 요청한 경우
![image](https://user-images.githubusercontent.com/66876894/236666147-e5cccafd-8f1b-4672-91b4-7bcdfe450eb7.png)

## USER로 로그인 하였을 경우
![image](https://user-images.githubusercontent.com/66876894/236666200-9147075e-be4b-466c-bc35-44af7df1151c.png)

- 유저가 게시글 답변 작성을 요청하게 되는 경우
![image](https://user-images.githubusercontent.com/66876894/236666232-d50299c8-0299-4fdb-9dc9-2c17784dc3f3.png)
- 403 상태코드 반환
---
예외처리는 추후 진행 예정

resolved: #18
